### PR TITLE
Adapt template docs and configuration for SAMS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
-project_name: golang-template
+project_name: sams
 builds:
   - main: ./cmd/app
-    ldflags: -X github.com/Enriquefft/golang-template/pkg/version.Version={{.Version}} -X github.com/Enriquefft/golang-template/pkg/version.Commit={{.FullCommit}} -X github.com/Enriquefft/golang-template/pkg/version.BuildDate={{.Date}}
+    ldflags: -X github.com/Enriquefft/SAMS/pkg/version.Version={{.Version}} -X github.com/Enriquefft/SAMS/pkg/version.Commit={{.FullCommit}} -X github.com/Enriquefft/SAMS/pkg/version.BuildDate={{.Date}}
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -11,4 +11,4 @@ checksum:
 release:
   github:
     owner: Enriquefft
-    name: golang-template
+    name: SAMS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This repository provides a **Go** starter template with Docker, GoReleaser, GolangCI-Lint and Nix flake support. It is meant to be cloned and adapted for your own projects. Update names, documentation and configuration files once you copy this template.
+This repository contains the code and automation for the **Self-Hosted Automated Mail Server (SAMS)** project. It includes Go utilities, Terraform modules, and Ansible playbooks to provision and manage multi-domain mail servers. Development follows strict type-safety and testing guidelines.
 
 ## Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-BINARY := app
+BINARY := sams
 
-.PHONY: all build test lint fmt clean vet govulncheck
+.PHONY: all build test lint fmt clean vet govulncheck healthcheck rotator tools
 
 all: build
 
@@ -24,3 +24,11 @@ govulncheck:
 
 clean:
 	rm -rf bin
+
+healthcheck:
+	go build -o bin/healthcheck ./tools/go-mailcow-healthcheck
+
+rotator:
+	go build -o bin/rotator ./tools/go-password-rotator
+
+tools: healthcheck rotator

--- a/README.md
+++ b/README.md
@@ -1,98 +1,70 @@
-# Golang Template
-[![CI](https://github.com/Enriquefft/golang-template/actions/workflows/ci.yml/badge.svg)](https://github.com/Enriquefft/golang-template/actions/workflows/ci.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/Enriquefft/golang-template.svg)](https://pkg.go.dev/github.com/Enriquefft/golang-template)
+# Self-Hosted Automated Mail Server (SAMS)
 
-
-A professional Go starter template featuring best practices and modern tooling: Go 1.22+ with generics, Docker, GitHub Actions, GoReleaser, GolangCI‑Lint, Dependabot, and Nix flakes for reproducible dev environments.
+SAMS provides infrastructure-as-code and automation for running a production-grade mail server on free-tier cloud resources. It uses Terraform to provision Oracle Cloud infrastructure and Ansible to deploy and manage [Mailcow](https://mailcow.email/). Passwords are stored in HashiCorp Vault and users access their mailboxes from Gmail via IMAP or POP3.
 
 ## Features
 
-- Go 1.22+ with modules and generics
-- Containerized with Docker and automated with GoReleaser
-- CI/CD using GitHub Actions workflows
-- Static analysis and linting with GolangCI‑Lint
-- Automated dependency updates via Dependabot
-- Reproducible development environment via Nix flake
-- Standard Go project layout (`cmd/`, `pkg/`, `internal/`)
-- Preconfigured testing and code coverage integrations
-
-## Technology Choices
-
-- **Go Modules** – Dependency management (`go.mod`, `go.sum`)
-- **GolangCI‑Lint** – Comprehensive static analysis (`.golangci.yml`)
-- **Docker & GoReleaser** – Container builds and release automation (`Dockerfile`, `.goreleaser.yml`)
-- **GitHub Actions** – CI/CD workflows (`.github/workflows/ci.yml`)
-- **Dependabot** – Automated dependency updates (`.github/dependabot.yml`)
-- **Nix Flake** – Reproducible dev shell (`flake.nix`)
-- **Makefile** – Common tasks (`make build`, `make test`, etc.)
+- Multi-domain support with automated onboarding and offboarding
+- Infrastructure provisioning with Terraform modules in `infra/`
+- Configuration management using Ansible roles in `automation/`
+- Backup scripts and monitoring alerts
+- Custom Go utilities in `tools/`
+- CI workflows for linting, testing and release
 
 ## Getting Started
 
-Clone the repository and enter the development environment:
+Clone the repository and initialize the development environment:
 
 ```bash
-git clone https://github.com/Enriquefft/golang-template.git
-cd golang-template
+git clone https://github.com/Enriquefft/SAMS.git
+cd SAMS
 nix develop
-````
+```
 
-Install Git hooks (recommended):
+Install Git hooks (optional):
 
 ```bash
 lefthook install
 ```
 
-Build and run:
+Run the example program:
 
 ```bash
 make build
-./bin/app
+./bin/sams
 ```
 
-## Available Commands
+## Makefile Commands
 
-* `make build` — Compile binaries
-* `make test` — Run tests and generate coverage
-* `make lint` — Run GolangCI‑Lint
-* `make govulncheck` — Scan for known vulnerabilities
-* `make fmt` — Format code with gofmt
-* `make release` — Publish via GoReleaser
-* `make docker-build` — Build Docker image locally
+- `make build` – compile the main binary to `bin/sams`
+- `make test` – run unit tests
+- `make lint` – run GolangCI-Lint
+- `make vet` – type-check with go vet
+- `make healthcheck` – build the Mailcow healthcheck CLI
+- `make rotator` – build the password rotator CLI
+- `make tools` – build all CLI tools
 
 ## Project Structure
-
-Adheres to the [Standard Go Project Layout](https://github.com/golang-standards/project-layout):
 
 ```
 ├── cmd/            # Application entrypoints
 ├── internal/       # Private packages
-├── pkg/            # Public packages
-├── configs/        # Configuration templates
-├── api/            # OpenAPI/Protobuf specs
-├── scripts/        # Build/deploy helpers
-├── docs/           # Documentation
-├── deployments/    # K8s/Docker Compose/Terraform manifests
-└── build/          # CI/CD and packaging scripts
+├── pkg/            # Public packages (e.g. version info)
+├── infra/          # Terraform modules
+├── automation/     # Ansible roles & playbooks
+├── docs/           # User and operator guides
+├── tools/          # Go utilities
+└── build/          # Release scripts
 ```
-
-## Environment Variables
-
-Configure in `.env`:
-
-```bash
-DATABASE_URL=postgres://user:pass@localhost:5432/db?sslmode=disable
-LOG_LEVEL=info
-PORT=8080
-```
-
-See `.env.example` for reference.
 
 ## Contributing
 
-Before submitting a PR:
+Before submitting a pull request:
 
 ```bash
 make fmt
 make lint
+make vet
 make test
 ```
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/Enriquefft/golang-template/internal/helloworld"
+	"github.com/Enriquefft/SAMS/internal/helloworld"
 )
 
 func main() {

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/Enriquefft/golang-template/internal/helloworld"
+	"github.com/Enriquefft/SAMS/internal/helloworld"
 )
 
 func TestMainGreet(t *testing.T) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
-# Documentation
+# SAMS Documentation
 
-Project documentation lives here.
+Detailed guides for deploying, operating and extending the Self-Hosted Automated Mail Server live in this directory.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Enriquefft/golang-template
+module github.com/Enriquefft/SAMS
 
 go 1.24.3
 

--- a/tools/go-mailcow-healthcheck/main.go
+++ b/tools/go-mailcow-healthcheck/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("mailcow healthcheck placeholder")
+}

--- a/tools/go-password-rotator/main.go
+++ b/tools/go-password-rotator/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("password rotator placeholder")
+}


### PR DESCRIPTION
## Summary
- rename module path to `github.com/Enriquefft/SAMS`
- configure GoReleaser for new repository
- rewrite README clone instructions and makefile section
- expand Makefile with CLI tool targets
- add placeholder healthcheck and password rotator utilities

## Testing
- `make fmt`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c8763b14c832097dd56a61e7adc62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced placeholder command-line tools for mail server health checks and password rotation.
* **Documentation**
  * Rewrote the README and documentation to describe and guide usage of the new Self-Hosted Automated Mail Server (SAMS) project.
  * Updated project and documentation titles and descriptions to reflect the SAMS branding.
* **Chores**
  * Renamed the project and updated all references, build configurations, and import paths from the old template to SAMS.
  * Updated Makefile targets and binary names to align with the new project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->